### PR TITLE
[ADD] reservation CREATE/DELETE

### DIFF
--- a/src/main/java/com/wellcom/domain/Desk/Desk.java
+++ b/src/main/java/com/wellcom/domain/Desk/Desk.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OptimisticLockType;
+import org.hibernate.annotations.OptimisticLocking;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
@@ -15,6 +17,7 @@ import java.time.LocalDateTime;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@OptimisticLocking(type = OptimisticLockType.DIRTY)
 public class Desk {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,8 +32,13 @@ public class Desk {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status isUsable;
+    @Version //Optimistic lock
+    private Long version;
     @CreationTimestamp
     private LocalDateTime createdTime;
     @UpdateTimestamp
     private LocalDateTime updatedTime;
+    public void updateIsUsable(String status) {
+        this.isUsable = Status.valueOf(status);
+    }
 }

--- a/src/main/java/com/wellcom/domain/Desk/Repository/DeskRepository.java
+++ b/src/main/java/com/wellcom/domain/Desk/Repository/DeskRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DeskRepository extends JpaRepository<Desk, Long> {
     List<Desk> findByIsUsableAndHasTV(Status isUsable, Status hasTV);
     List<Desk> findByIsUsable(Status isUsable);
     List<Desk> findByHasTV(Status hasTV);
+    Optional<Desk> findByDeskNum(int deskNum);
 }

--- a/src/main/java/com/wellcom/domain/Desk/Service/DeskService.java
+++ b/src/main/java/com/wellcom/domain/Desk/Service/DeskService.java
@@ -7,6 +7,7 @@ import com.wellcom.domain.Desk.Repository.DeskRepository;
 import com.wellcom.domain.Desk.Status;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,5 +50,11 @@ public class DeskService {
     public List<DeskResDto> findAllByHasTV(Status hasTV) {
         List<Desk> desks = deskRepository.findByHasTV(hasTV);
         return mapDesksToDeskResDtoList(desks);
+    }
+
+    public void updateDeskStatus(int deskNum, String status)
+    {
+        Desk desk = deskRepository.findByDeskNum(deskNum).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 테이블 번호입니다."));
+        desk.updateIsUsable(status);
     }
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Controller/ReservationController.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Controller/ReservationController.java
@@ -1,7 +1,34 @@
 package com.wellcom.domain.Reservation.Controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.wellcom.domain.Reservation.Dto.ReservationCreateReqDto;
+import com.wellcom.domain.Reservation.Reservation;
+import com.wellcom.domain.Reservation.Service.ReservationService;
+import com.wellcom.global.common.CommonResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class ReservationController {
+    private final ReservationService reservationService;
+    @Autowired
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+    @PostMapping("/reservation/create")
+    public ResponseEntity<CommonResponse> saveReservation(@RequestBody ReservationCreateReqDto reservationCreateReqDto){
+        Reservation reservation = reservationService.saveReservation(reservationCreateReqDto);
+        return new ResponseEntity<>(new CommonResponse(HttpStatus.CREATED, "예약 성공", reservation.getReservationId()),HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/reservation/{reservation_id}/cancel")
+    public ResponseEntity<CommonResponse> cancelReservation(@PathVariable String reservation_id){
+        return new ResponseEntity<>(new CommonResponse(HttpStatus.NO_CONTENT, "예약이 취소되었습니다", reservationService.cancelReservation(reservation_id)), HttpStatus.NO_CONTENT);
+    }
+
+    @PatchMapping("/reservation/{reservation_id}/update")
+    public ResponseEntity<CommonResponse> updateReservation(@PathVariable String reservation_id){
+        return new ResponseEntity<>(new CommonResponse(HttpStatus.OK, "예약이 수정되었습니다", reservationService.updatelReservation(reservation_id)), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Dto/ReservationCreateReqDto.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Dto/ReservationCreateReqDto.java
@@ -1,0 +1,16 @@
+package com.wellcom.domain.Reservation.Dto;
+
+import com.wellcom.domain.Member.Member;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReservationCreateReqDto
+{
+    private Member member;
+    private int deskNum;
+    private int cntPeople;
+    private LocalDateTime startTime;
+    private int minutes;
+}

--- a/src/main/java/com/wellcom/domain/Reservation/Dto/testDto.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Dto/testDto.java
@@ -1,4 +1,0 @@
-package com.wellcom.domain.Reservation.Dto;
-
-public class testDto {
-}

--- a/src/main/java/com/wellcom/domain/Reservation/Repository/ReservationRepository.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Repository/ReservationRepository.java
@@ -1,9 +1,20 @@
 package com.wellcom.domain.Reservation.Repository;
 
+import com.wellcom.domain.Member.Member;
 import com.wellcom.domain.Reservation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Reservation findByReservationIdAndMember(String reservationId, Member member);
+    Optional<Reservation> findByReservationId(String reservationId);
+    @Query("SELECT r FROM Reservation r WHERE r.desk.deskNum = :deskNum AND r.endTime > :currentTime AND (r.status = 'WAITING' OR r.status = 'USING')")
+    List<Reservation> findActiveReservationsByDeskAndTime(@Param("deskNum") int deskNum, @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Reservation.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Reservation.java
@@ -1,6 +1,5 @@
 package com.wellcom.domain.Reservation;
 
-
 import com.wellcom.domain.Desk.Desk;
 import com.wellcom.domain.Member.Member;
 import lombok.AllArgsConstructor;
@@ -12,7 +11,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @Builder
@@ -23,6 +21,9 @@ public class Reservation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String reservationId;
 
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch= FetchType.LAZY)
@@ -36,12 +37,10 @@ public class Reservation {
     private LocalDateTime startTime;
 
     @Column(nullable = false)
-    private LocalDateTime reservationTime;
+    private int reservationTime;
 
     @Column(nullable = false)
     private LocalDateTime endTime;
-
-    //private uuid
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -55,4 +54,9 @@ public class Reservation {
 
     @UpdateTimestamp
     private LocalDateTime updatedTime;
+
+    public void setStatus(String status){
+        this.status = Status.valueOf(status);
+    }
+
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Service/ReservationNumberGenerator.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Service/ReservationNumberGenerator.java
@@ -1,0 +1,19 @@
+package com.wellcom.domain.Reservation.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ReservationNumberGenerator
+{
+    // 예약 번호 생성 메서드
+    public static String generateReservationNumber() {
+        // 현재 날짜 및 시간을 가져옴
+        LocalDateTime now = LocalDateTime.now();
+        // 날짜를 형식에 맞게 포맷팅 (예: yyyyMMddHHmmss)
+        String formattedDate = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        // 짧은 값을 랜덤으로 생성
+        int shortValue = (int) (Math.random() * 1000);
+        // 날짜와 짧은 값을 조합하여 예약 번호 생성
+        return formattedDate + String.format("%03d", shortValue);
+    }
+}

--- a/src/main/java/com/wellcom/domain/Reservation/Service/ReservationScheduler.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Service/ReservationScheduler.java
@@ -1,0 +1,73 @@
+package com.wellcom.domain.Reservation.Service;
+
+import com.wellcom.domain.Desk.Desk;
+import com.wellcom.domain.Desk.Service.DeskService;
+import com.wellcom.domain.Reservation.Repository.ReservationRepository;
+import com.wellcom.domain.Reservation.Reservation;
+import com.wellcom.domain.Reservation.Status;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+@Component
+@Slf4j
+public class ReservationScheduler {
+    private final TaskScheduler taskScheduler;
+    private final DeskService deskService;
+    private final ReservationRepository reservationRepository;
+    @Autowired
+    public ReservationScheduler(TaskScheduler taskScheduler, DeskService deskService, ReservationRepository reservationRepository) {
+        this.taskScheduler = taskScheduler;
+        this.deskService = deskService;
+        this.reservationRepository = reservationRepository;
+    }
+    private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+    public void scheduleReservationEnd(Reservation reservation){
+        LocalDateTime endTime = reservation.getEndTime();
+        int deskNum = reservation.getDesk().getDeskNum();
+        String reservationId = reservation.getReservationId();
+
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> {
+            log.info("예약된 작업시작: 예약번호" + reservationId + "처리 / " + deskNum + "번 테이블 사용가능");
+            deskService.updateDeskStatus(deskNum, "Y");
+            updateReservationStatus(reservationId, "COMPLETE");
+            }, Date.from(endTime.atZone(ZoneId.systemDefault()).toInstant()));
+        scheduledTasks.put(reservation.getReservationId(), future);
+    }
+    public void scheduleReservationStart(Reservation reservation) {
+        LocalDateTime startTime = reservation.getStartTime();
+        int deskNum = reservation.getDesk().getDeskNum();
+        String reservationId = reservation.getReservationId();
+
+        ScheduledFuture<?> future = taskScheduler.schedule(() -> {
+            log.info("예약 시작 작업: 예약번호 " + reservationId + " / " + deskNum + "번 테이블 사용 시작");
+            deskService.updateDeskStatus(deskNum, "N");
+            updateReservationStatus(reservationId, "USING");
+        }, Date.from(startTime.atZone(ZoneId.systemDefault()).toInstant()));
+        scheduledTasks.put("start_" + reservation.getReservationId(), future);
+    }
+    private void updateReservationStatus(String reservationId, String status) {
+        Reservation reservation = reservationRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new EntityNotFoundException("예약번호 "+ reservationId + "를 찾을 수 없습니다."));
+        reservation.setStatus(status);
+        reservationRepository.save(reservation);
+    }
+    public void cancelFutureSchedule(String reservationId) {
+        System.out.println("---------------------사이즈: "+scheduledTasks.size()+" -----------------");
+        ScheduledFuture<?> future = scheduledTasks.get(reservationId);
+        if (future != null){
+            future.cancel(false);
+            scheduledTasks.remove(reservationId);
+            System.out.println("---------------------사이즈: "+scheduledTasks.size()+" -----------------");
+        }
+    }
+}

--- a/src/main/java/com/wellcom/domain/Reservation/Service/ReservationService.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Service/ReservationService.java
@@ -1,10 +1,111 @@
 package com.wellcom.domain.Reservation.Service;
 
+import com.wellcom.domain.Desk.Desk;
+import com.wellcom.domain.Desk.Repository.DeskRepository;
+import com.wellcom.domain.Member.Member;
+import com.wellcom.domain.Member.Repository.MemberRepository;
+import com.wellcom.domain.Reservation.Dto.ReservationCreateReqDto;
+import com.wellcom.domain.Reservation.Repository.ReservationRepository;
+import com.wellcom.domain.Reservation.Reservation;
+import com.wellcom.domain.Reservation.Status;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
 public class ReservationService {
+    private final ReservationRepository reservationRepository;
+    private final MemberRepository memberRepository;
+    private final DeskRepository deskRepository;
+    private final ReservationScheduler reservationScheduler;
+    public ReservationService(ReservationRepository reservationRepository, MemberRepository memberRepository, DeskRepository deskRepository, ReservationScheduler reservationScheduler) {
+        this.reservationRepository = reservationRepository;
+        this.memberRepository = memberRepository;
+        this.deskRepository = deskRepository;
+        this.reservationScheduler = reservationScheduler;
+    }
+    private Member findMemberByEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("Member does not exist: " + email));
+    } //맴버 뽑아내기 공통화
+    private Desk findDeskByDeskNum(int deskNum) {
+        return deskRepository.findByDeskNum(deskNum)
+                .orElseThrow(() -> new EntityNotFoundException("Desk dose not exist: " + deskNum));
+    } // 테이블 뽑아내기 공통화
+    private Reservation findByReservationIdAndEmail(String reservationId){
+        Member member = this.findMemberByEmail();
+        return reservationRepository.findByReservationIdAndMember(reservationId, member);
+    } // 유저가 예약했던 예약찾기(조건 둘 다 만족해야함)
+    private boolean isReservationPossible(int deskNum, LocalDateTime startTime, int durationMinutes) {
+        LocalDateTime endTime = startTime.plusMinutes(durationMinutes);
+        List<Reservation> activeReservations = reservationRepository.findActiveReservationsByDeskAndTime(deskNum, LocalDateTime.now());
+        for (Reservation reservation : activeReservations) {
+            if (startTime.isBefore(reservation.getEndTime()) && endTime.isAfter(reservation.getStartTime()))
+                return false;
+        }
+        return true; // 요청된 예약 시간이 기존의 어떤 예약과도 겹치지 않음
+    }
+    public Reservation saveReservation(ReservationCreateReqDto reservationCreateReqDto) {
+        Member member = this.findMemberByEmail();
+        Desk desk = this.findDeskByDeskNum(reservationCreateReqDto.getDeskNum());
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        if (!isReservationPossible(desk.getDeskNum(), reservationCreateReqDto.getStartTime(), reservationCreateReqDto.getMinutes()))
+            throw new IllegalArgumentException("선택한 시간에 예약이 불가능합니다.");
+        if (desk.getSeats() < reservationCreateReqDto.getCntPeople())
+            throw new IllegalArgumentException("테이블 사용 가능 인원을 초과했습니다.");
+        if (reservationCreateReqDto.getStartTime().isBefore(currentTime.minusSeconds(5L)))
+            throw new IllegalArgumentException("잘못된 시간을 선택하셨습니다.");
+
+        Status reservationStatus = Status.WAITING;
+
+        Reservation reservation = Reservation.builder()
+                .reservationId(ReservationNumberGenerator.generateReservationNumber())
+                .member(member)
+                .desk(desk)
+                .status(reservationStatus) // 초기 상태 설정
+                .startTime(reservationCreateReqDto.getStartTime())
+                .cntPeople(reservationCreateReqDto.getCntPeople())
+                .reservationTime(reservationCreateReqDto.getMinutes())
+                .endTime(reservationCreateReqDto.getStartTime().plusMinutes(reservationCreateReqDto.getMinutes()))
+                .build();
+        // 즉시 사용
+        if (Duration.between(currentTime, reservationCreateReqDto.getStartTime()).abs().getSeconds() <= 5) {
+            reservation.setStatus("USING");
+            desk.updateIsUsable("N");
+            Reservation savedReservation = reservationRepository.save(reservation);
+            reservationScheduler.scheduleReservationEnd(savedReservation);
+            return savedReservation;
+        } else {
+            Reservation savedReservation = reservationRepository.save(reservation);
+            reservationScheduler.scheduleReservationStart(savedReservation);
+            reservationScheduler.scheduleReservationEnd(savedReservation);
+            return savedReservation;
+        }
+    }
+    public String cancelReservation(String reservationId) {
+        Reservation reservation = this.findByReservationIdAndEmail(reservationId);
+        if(reservation == null) throw new EntityNotFoundException("잘못된 예약번호입니다.");
+        reservationScheduler.cancelFutureSchedule(reservationId);
+        reservation.setStatus("CANCELED");
+        Desk desk =  reservation.getDesk();
+        desk.updateIsUsable("Y");
+        return reservationRepository.save(reservation).getReservationId();
+    }
+
+    public String updatelReservation(String reservationId)
+    {
+        //예약 수정은 없고 취소 후 다시 예약이 가능하게 하는 방법?
+        return null;
+    }
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Status.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Status.java
@@ -1,5 +1,5 @@
 package com.wellcom.domain.Reservation;
 
 public enum Status {
-    COMPLETE, WAITING, CANCELED
+    COMPLETE, WAITING, USING, CANCELED
 }

--- a/src/main/java/com/wellcom/global/config/SchedulerConfig.java
+++ b/src/main/java/com/wellcom/global/config/SchedulerConfig.java
@@ -1,0 +1,19 @@
+package com.wellcom.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+//EnableScheduling 사용안하고 직접 설정
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("ThreadPoolTaskScheduler");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/wellcom/global/config/SecurityConfig.java
+++ b/src/main/java/com/wellcom/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 // permit 처리 방법 두 가지 중 url 정해지는 것 보고 선택
                 .authorizeRequests()
                 .antMatchers("/user/**").authenticated()
-                .antMatchers("/admin/**").hasAuthority("ADMIN")
+                .antMatchers("/admin/**", "/desk/**").hasRole("ADMIN")
                 .anyRequest().permitAll()
 /*                .authorizeRequests()
                 .antMatchers("/","/css/**","/images/**","/js/**","/favicon.ico").permitAll()


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 예약 즉시 생성 및 대기예약 로직 구현(스케줄링)
- 예약 캔슬 구현
- 테이블 엔티티 Version 관리 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 예약관리

- 예약 요청 시간을 기준으로 즉시사용/예약 구분.
- 멀티쓰레딩 스케줄러를 사용해 예약의 상태와 테이블의 상태 관리 최신화.
- 예약의 중복과 동시성관리는 UUID대신 직접 랜덤하게 생성한 예약번호와 Concurrenthashmap을 사용해 중복된 예약작업을 방지하고, 테이블에 version jpa어노테이션을 사용해 버전관리로 동시성 관리.


<br />

## :: Issue 포인트 ( 해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 사용자 입력시간과 서버에 들어오는 시간과의 간극이 불안요소.
- 정확한 시간관리가 어려움 -> 사용자에게 세분화된 시간선택권한을 주지 못할수도 있음.
- 동시성 테스트 미완.

