### PR TITLE
[FIX] 에약 로직에서 발생한 에러 및 버그 수정

### DIFF
--- a/src/main/java/com/wellcom/domain/Reservation/Controller/ReservationController.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Controller/ReservationController.java
@@ -26,9 +26,4 @@ public class ReservationController {
     public ResponseEntity<CommonResponse> cancelReservation(@PathVariable String reservation_id){
         return new ResponseEntity<>(new CommonResponse(HttpStatus.NO_CONTENT, "예약이 취소되었습니다", reservationService.cancelReservation(reservation_id)), HttpStatus.NO_CONTENT);
     }
-
-    @PatchMapping("/reservation/{reservation_id}/update")
-    public ResponseEntity<CommonResponse> updateReservation(@PathVariable String reservation_id){
-        return new ResponseEntity<>(new CommonResponse(HttpStatus.OK, "예약이 수정되었습니다", reservationService.updatelReservation(reservation_id)), HttpStatus.OK);
-    }
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Repository/ReservationRepository.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Repository/ReservationRepository.java
@@ -15,6 +15,6 @@ import java.util.Optional;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     Reservation findByReservationIdAndMember(String reservationId, Member member);
     Optional<Reservation> findByReservationId(String reservationId);
-    @Query("SELECT r FROM Reservation r WHERE r.desk.deskNum = :deskNum AND r.endTime > :currentTime AND (r.status = 'WAITING' OR r.status = 'USING')")
+    @Query("SELECT r FROM Reservation r WHERE r.desk.deskNum = :deskNum AND r.startTime > :currentTime AND (r.status = 'WAITING' OR r.status = 'USING')")
     List<Reservation> findActiveReservationsByDeskAndTime(@Param("deskNum") int deskNum, @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/wellcom/domain/Reservation/Service/ReservationService.java
+++ b/src/main/java/com/wellcom/domain/Reservation/Service/ReservationService.java
@@ -88,8 +88,8 @@ public class ReservationService {
             return savedReservation;
         } else {
             Reservation savedReservation = reservationRepository.save(reservation);
-            reservationScheduler.scheduleReservationStart(savedReservation);
             reservationScheduler.scheduleReservationEnd(savedReservation);
+            reservationScheduler.scheduleReservationStart(savedReservation);
             return savedReservation;
         }
     }
@@ -98,14 +98,8 @@ public class ReservationService {
         if(reservation == null) throw new EntityNotFoundException("잘못된 예약번호입니다.");
         reservationScheduler.cancelFutureSchedule(reservationId);
         reservation.setStatus("CANCELED");
-        Desk desk =  reservation.getDesk();
-        desk.updateIsUsable("Y");
+//        Desk desk =  reservation.getDesk();
+//        desk.updateIsUsable("Y");
         return reservationRepository.save(reservation).getReservationId();
-    }
-
-    public String updatelReservation(String reservationId)
-    {
-        //예약 수정은 없고 취소 후 다시 예약이 가능하게 하는 방법?
-        return null;
     }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Hotfix

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 예약 취소시 예약의 시작과 종료를 ConcurrentHashMap에 넣을때 동일한 예약 id로 넣어서 시작 또는 종료 예약 한가지만 삭제되어지는 에러가 발생

- 각 예약에 시작과 종료 작업 태그를 예약번호에 추가하고 HashMap에서 해당 예약id 전부 삭제
- 해당 예약이 완료 되었음에도 상태값이 계속 사용중 상태이거나, 완료되지 않았지만 완료상태로 바뀌는 버그 수정

2. 테이블의 예약 취소시 해당 테이블의 예약 시간에 다른 사용자가 재 예약이 불가능한 에러가 발생

- jpql문을 수정 후 버그 수정

3.  테이블 예약 요청이 사용대기 상태인 WAITING 상태로 예약 될 경우, 시작과 종료 작업이 서로 섞여서 실행되어지는 에러 발생

![image](https://github.com/jungsae/Well-Com/assets/81615965/39cd1105-ed4f-4c89-9b11-7fac3585f610)

- 예약 시작 작업들을 예약 종료 작업들 보다 딜레이(1초)를 걸어줘 양쪽 작업들끼리의 그룹 블록 생성 후 섞임을 방지
- 시작과 종료 작업이 뒤죽박죽 섞여 들어가서 예약 상태 데이터 무결성이 파괴되는 버그 수정

![image](https://github.com/jungsae/Well-Com/assets/81615965/68c283c3-6496-4b63-bbdf-93166e2921c1)

<br />

## :: 기타 질문 및 특이 사항

- 예약 수정기능 제외
